### PR TITLE
Update PHP_CodeSniffer info

### DIFF
--- a/_projects/squizlabs/phpcbf.md
+++ b/_projects/squizlabs/phpcbf.md
@@ -4,12 +4,13 @@ title:              'PHP Code Beautifier and Fixer'
 order:              'php code beautifier and fixer'
 tags:               ['coding standards', 'code fixer', 'code beautifier', 'cli'] 
 
-authors:            [{name: 'Greg Sherwood'}] 
+authors:            [{name: 'Greg Sherwood'}, {name: 'Juliette Reinders Folmer'}]
 
-website:            [{url: 'https://pear.php.net/package/PHP_CodeSniffer'}]
-license:            [{url: 'https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt', label: 'BSD 3-clause "New" or "Revised" License'}]
+website:            [{url: 'https://github.com/PHPCSStandards/PHP_CodeSniffer/'}]
+license:            [{url: 'https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt', label: 'BSD 3-clause "New" or "Revised" License'}]
+wiki:               [{url: 'https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki'}]
 
-github:             [{name: 'squizlabs/PHP_CodeSniffer'}]
+github:             [{name: 'PHPCSStandards/PHP_CodeSniffer'}]
 packagist:          [{name: 'squizlabs/php_codesniffer'}]               
 dockerhub:          [{name: 'phpqa/phpcbf'}]     
 
@@ -17,7 +18,7 @@ dependencies:       []
 composer-dev:       {command: 'vendor/bin/phpcbf'}
 composer-global:    {command: 'phpcbf'}
 git:                {command: 'bin/phpcbf'}
-phar:               {url: 'https://squizlabs.github.io/PHP_CodeSniffer/phpcbf.phar'}
+phar:               {url: 'http://phars.phpcodesniffer.com/phpcbf.phar'}
 
 ---
 

--- a/_projects/squizlabs/phpcs.md
+++ b/_projects/squizlabs/phpcs.md
@@ -4,13 +4,13 @@ title:              'PHP_CodeSniffer'
 order:              'php_codesniffer'
 tags:               ['coding standards', 'cli']
 
-authors:            [{name: 'Greg Sherwood'}] 
+authors:            [{name: 'Greg Sherwood'}, {name: 'Juliette Reinders Folmer'}]
 
-website:            [{url: 'https://pear.php.net/package/PHP_CodeSniffer'}]
-wiki:               [{url: 'https://github.com/squizlabs/PHP_CodeSniffer/wiki'}]
-license:            [{url: 'https://github.com/squizlabs/PHP_CodeSniffer/blob/master/licence.txt', label: 'BSD 3-clause "New" or "Revised" License'}]
+website:            [{url: 'https://github.com/PHPCSStandards/PHP_CodeSniffer/'}]
+license:            [{url: 'https://github.com/PHPCSStandards/PHP_CodeSniffer/blob/master/licence.txt', label: 'BSD 3-clause "New" or "Revised" License'}]
+wiki:               [{url: 'https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki'}]
 
-github:             [{name: 'squizlabs/PHP_CodeSniffer'}]
+github:             [{name: 'PHPCSStandards/PHP_CodeSniffer'}]
 packagist:          [{name: 'squizlabs/php_codesniffer'}]               
 dockerhub:          [{name: 'phpqa/phpcs'}]     
 
@@ -18,8 +18,7 @@ dependencies:       []
 composer-dev:       {command: 'vendor/bin/phpcs'}  
 composer-global:    {command: 'phpcs'} 
 git:                {command: 'bin/phpcs'}
-pear:               {name: 'PHP_CodeSniffer'}
-phar:               {url: 'https://squizlabs.github.io/PHP_CodeSniffer/phpcs.phar'}
+phar:               {url: 'http://phars.phpcodesniffer.com/phpcs.phar'}
 
 ---
 


### PR DESCRIPTION
PHP_CodeSniffer is under new management. See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932

Also note that installation via PEAR is no longer supported.